### PR TITLE
feat: add sys_traits::auto_impl proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,7 +267,7 @@ dependencies = [
 
 [[package]]
 name = "sys_traits"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "filetime",
  "getrandom",
@@ -276,9 +276,19 @@ dependencies = [
  "parking_lot",
  "serde",
  "serde_json",
+ "sys_traits_macros",
  "tempfile",
  "wasm-bindgen",
  "windows-sys",
+]
+
+[[package]]
+name = "sys_traits_macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sys_traits"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/dsherret/sys_traits"
@@ -11,6 +11,7 @@ all-features = true
 
 [workspace]
 members = [
+  "macros",
   "tests/wasm_test",
 ]
 
@@ -32,6 +33,7 @@ filetime = { version = "0.2", optional = true }
 parking_lot = { version = "0.12", optional = true }
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+sys_traits_macros = { version = "0.1", path = "./macros" }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 getrandom = { version = "0.2", optional = true }

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ pub fn write_random_data<TSys: FsWriteFile + SystemRandom>(
 
 Now a caller only needs to provide a type that implements those two functions.
 
+## `#[sys_traits::auto_impl]`
+
+Use the `#[sys_traits::auto_impl]` macro to reduce boilerplate when wanting to
+automatically implement a trait for `T` when `T` implements the required traits.
+
+This is useful for aliasing and reducing verbosity when using this crate.
+
+```diff
++#[sys_traits::auto_impl]
+pub trait WriteRandomDataSys: FsWriteFile + SystemRandom
+{
+}
+
+-impl<T> DenoResolverSys for T where T: FsWriteFile + SystemRandom
+-{
+-}
+```
+
 ## Implementations
 
 Comes with two implementations that implement all the traits.
@@ -69,23 +87,3 @@ There's two reasons for this:
 1. You can't box traits with `impl ...`.
 2. By design it limits code generation of multiple kinds of `impl AsRef<Path>`
    and `impl AsRef<[u8]>` to only being a single statement.
-
-## `#[sys_traits::auto_impl]`
-
-Use the `#[sys_traits::auto_impl]` macro to reduce boilerplate when wanting to
-automatically implement a trait for `T` when `T` implements the required traits.
-
-This is useful for aliasing and reducing verbosity when using this crate.
-
-```diff
-+#[sys_traits::auto_impl]
-pub trait DenoResolverSys:
-  FsCanonicalize + FsMetadata + FsRead + FsReadDir + std::fmt::Debug
-{
-}
-
--impl<T> DenoResolverSys for T where
--  T: FsCanonicalize + FsMetadata + FsRead + FsReadDir + std::fmt::Debug
--{
--}
-```

--- a/README.md
+++ b/README.md
@@ -69,3 +69,23 @@ There's two reasons for this:
 1. You can't box traits with `impl ...`.
 2. By design it limits code generation of multiple kinds of `impl AsRef<Path>`
    and `impl AsRef<[u8]>` to only being a single statement.
+
+## `#[sys_traits::auto_impl]`
+
+Use the `#[sys_traits::auto_impl]` macro to reduce boilerplate when wanting to
+automatically implement a trait for `T` when `T` implements the required traits.
+
+This is useful for aliasing and reducing verbosity when using this crate.
+
+```diff
++#[sys_traits::auto_impl]
+pub trait DenoResolverSys:
+  FsCanonicalize + FsMetadata + FsRead + FsReadDir + std::fmt::Debug
+{
+}
+
+-impl<T> DenoResolverSys for T where
+-  T: FsCanonicalize + FsMetadata + FsRead + FsReadDir + std::fmt::Debug
+-{
+-}
+```

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "sys_traits_macros"
+version = "0.1.0"
+edition = "2021"
+license = "MIT"
+repository = "https://github.com/dsherret/sys_traits"
+description = "Procedural macros for sys_traits."
+
+[lib]
+path = "lib.rs"
+proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }

--- a/macros/lib.rs
+++ b/macros/lib.rs
@@ -1,0 +1,19 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::parse_macro_input;
+use syn::ItemTrait;
+
+#[proc_macro_attribute]
+pub fn auto_impl(_attr: TokenStream, item: TokenStream) -> TokenStream {
+  let input = parse_macro_input!(item as ItemTrait);
+  let trait_ident = &input.ident;
+  let supertraits = &input.supertraits;
+
+  let expanded = quote! {
+      #input
+
+      impl<T> #trait_ident for T where T: #supertraits {}
+  };
+
+  TokenStream::from(expanded)
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.86.0"
 components = ["clippy", "rustfmt"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use std::time::SystemTime;
 pub mod boxed;
 pub mod impls;
 
+pub use sys_traits_macros::auto_impl;
+
 // #### ENVIRONMENT ####
 
 // == EnvCurrentDir ==


### PR DESCRIPTION
```diff
+#[sys_traits::auto_impl]
pub trait DenoResolverSys:
  FsCanonicalize + FsMetadata + FsRead + FsReadDir + std::fmt::Debug
{
}

-impl<T> DenoResolverSys for T where
-  T: FsCanonicalize + FsMetadata + FsRead + FsReadDir + std::fmt::Debug
-{
-}
```

Closes https://github.com/dsherret/sys_traits/issues/43