### PR TITLE
fix:  make `InMemorySys::fs_canonicalize` return `NotFound` error for empty paths

### DIFF
--- a/src/impls/in_memory.rs
+++ b/src/impls/in_memory.rs
@@ -526,6 +526,9 @@ impl EnvSetUmask for InMemorySys {
 
 impl BaseFsCanonicalize for InMemorySys {
   fn base_fs_canonicalize(&self, path: &Path) -> Result<PathBuf> {
+    if path.as_os_str().is_empty() {
+      return Err(Error::new(ErrorKind::NotFound, "No such file or directory"));
+    }
     let inner = self.0.read();
     let path = inner.to_absolute_path(path);
     let (path, _) = inner.lookup_entry(&path)?;

--- a/src/impls/in_memory.rs
+++ b/src/impls/in_memory.rs
@@ -1774,6 +1774,15 @@ mod tests {
   }
 
   #[test]
+  fn test_fs_canonicalize_empty() {
+    let sys = InMemorySys::default();
+    sys.fs_create_dir_all("/a/b/c").unwrap();
+    sys.env_set_current_dir("/a/b").unwrap();
+    let result = sys.fs_canonicalize("");
+    assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::NotFound);
+  }
+
+  #[test]
   fn test_sys_random_no_seed() {
     let sys = InMemorySys::default();
     let mut buf1 = [0u8; 8];

--- a/src/impls/real.rs
+++ b/src/impls/real.rs
@@ -1176,4 +1176,10 @@ mod test {
       assert_eq!(result.unwrap_err().kind(), ErrorKind::Unsupported);
     }
   }
+
+  #[test]
+  fn test_fs_canonicalize_empty() {
+    let result = RealSys.fs_canonicalize("");
+    assert_eq!(result.unwrap_err().kind(), ErrorKind::NotFound);
+  }
 }

--- a/tests/wasm_test/src/lib.rs
+++ b/tests/wasm_test/src/lib.rs
@@ -251,12 +251,7 @@ fn run() -> std::io::Result<()> {
   }
 
   // permissions
-  if is_windows {
-    let err = sys.fs_set_permissions("file.txt", 0o0777).unwrap_err();
-    assert_eq!(err.kind(), ErrorKind::Unsupported);
-  } else {
-    sys.fs_set_permissions("file.txt", 0o0777).unwrap();
-  }
+  sys.fs_set_permissions("file.txt", 0o0777).unwrap();
 
   // copy file
   sys.fs_copy("file.txt", "copy.txt").unwrap();


### PR DESCRIPTION
Fixes #61 